### PR TITLE
Implement GNATdoc indented code blocks.

### DIFF
--- a/.aspell/.aspell.en.pws
+++ b/.aspell/.aspell.en.pws
@@ -5,6 +5,7 @@ cip
 commonmark
 deallocation
 elsif
+gnatdoc
 parsers
 pragma
 pre

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "ada.projectFile": "gnat/markdown.gpr",
+    "ada.projectFile": "gnat/tests/commonmark_tests.gpr",
     "ada.renameInComments": true,
     "[ada]": {
         "editor.rulers": [80],

--- a/alire.toml
+++ b/alire.toml
@@ -13,3 +13,5 @@ project-files = ["gnat/markdown.gpr"]
 
 [[depends-on]]
 vss = "^22.0.0"
+[[pins]]
+vss = { path='../VSS' }

--- a/gnat/tests/commonmark_tests.gpr
+++ b/gnat/tests/commonmark_tests.gpr
@@ -10,8 +10,10 @@ with "markdown";
 project CommonMark_Tests is
 
    for Object_Dir use "../" & Markdown'Object_Dir & "/tests";
-   for Source_Dirs use ("../../testsuite/commonmark");
-   for Main use ("commonmark_tests.adb");
+   for Source_Dirs use
+     ("../../testsuite/commonmark",
+      "../../testsuite/gnatdoc");
+   for Main use ("commonmark_tests.adb", "gnatdoc_tests.adb");
 
    package Compiler is
       for Default_Switches ("Ada") use Markdown.Ada_Switches & ("-gnatW8");

--- a/source/parser/implementation/markdown-blocks.adb
+++ b/source/parser/implementation/markdown-blocks.adb
@@ -51,7 +51,7 @@ package body Markdown.Blocks is
    begin
       return Self.Data.Assigned
         and then Self.Data.all in
-          Markdown.Implementation.Indented_Code_Blocks.Indented_Code_Block;
+          Implementation.Indented_Code_Blocks.Indented_Code_Block'Class;
    end Is_Indented_Code_Block;
 
    -------------

--- a/source/parser/implementation/markdown-implementation-indented_code_blocks-gnatdoc.adb
+++ b/source/parser/implementation/markdown-implementation-indented_code_blocks-gnatdoc.adb
@@ -1,0 +1,50 @@
+--
+--  Copyright (C) 2021-2022, AdaCore
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
+package body Markdown.Implementation.Indented_Code_Blocks.GNATdoc is
+
+   overriding function Create
+     (Input : not null access Input_Position) return GNATdoc_Code_Block
+   is
+      Match : constant VSS.Regular_Expressions.Regular_Expression_Match :=
+        Indent.Match (Input.Line.Expanded, Input.First);
+   begin
+      return Result : GNATdoc_Code_Block do
+         Result.Indent := Match.Marker.Character_Length;
+         Forward (Input.First, Result.Indent);
+         Result.Lines.Append (Input.Line.Unexpanded_Tail (Input.First));
+         --  Shift Input.First to end-of-line
+         Input.First.Set_After_Last (Input.Line.Expanded);
+      end return;
+   end Create;
+
+   --------------
+   -- Detector --
+   --------------
+
+   procedure Detector
+     (Input : Input_Position;
+      Tag   : in out Ada.Tags.Tag;
+      CIP   : out Can_Interrupt_Paragraph)
+   is
+      use type VSS.Strings.Character_Count;
+
+      Match : VSS.Regular_Expressions.Regular_Expression_Match;
+   begin
+      if not Indent.Is_Valid then  --  Construct Indent regexp
+         Indent := VSS.Regular_Expressions.To_Regular_Expression
+           ("^  *");  --  XXX: Replace with "^ +"
+      end if;
+
+      Match := Indent.Match (Input.Line.Expanded, Input.First);
+
+      if Match.Has_Match and then Match.Marker.Character_Length >= 3 then
+         Tag := GNATdoc_Code_Block'Tag;
+         CIP := False;
+      end if;
+   end Detector;
+
+end Markdown.Implementation.Indented_Code_Blocks.GNATdoc;

--- a/source/parser/implementation/markdown-implementation-indented_code_blocks-gnatdoc.ads
+++ b/source/parser/implementation/markdown-implementation-indented_code_blocks-gnatdoc.ads
@@ -1,0 +1,24 @@
+--
+--  Copyright (C) 2021-2022, AdaCore
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
+--  A variant of indented code blocks used in GNATdoc.
+--  It's indented with 3 or more spaces
+
+package Markdown.Implementation.Indented_Code_Blocks.GNATdoc is
+   pragma Preelaborate;
+
+   type GNATdoc_Code_Block is new Indented_Code_Block with null record;
+
+   overriding function Create
+     (Input : not null access Input_Position) return GNATdoc_Code_Block;
+
+   procedure Detector
+     (Input : Input_Position;
+      Tag   : in out Ada.Tags.Tag;
+      CIP   : out Can_Interrupt_Paragraph);
+   --  The detector procedure to find start of a gnatdoc code block
+
+end Markdown.Implementation.Indented_Code_Blocks.GNATdoc;

--- a/source/parser/implementation/markdown-implementation-indented_code_blocks.ads
+++ b/source/parser/implementation/markdown-implementation-indented_code_blocks.ads
@@ -6,6 +6,8 @@
 
 --  Internal representation of a indented code blocks
 
+private with VSS.Regular_Expressions;
+
 with VSS.String_Vectors;
 
 package Markdown.Implementation.Indented_Code_Blocks is
@@ -27,7 +29,8 @@ package Markdown.Implementation.Indented_Code_Blocks is
 private
 
    type Indented_Code_Block is new Abstract_Block with record
-      Lines : VSS.String_Vectors.Virtual_String_Vector;
+      Indent : VSS.Strings.Character_Count := 4;  --  Overridden in GNATdoc
+      Lines  : VSS.String_Vectors.Virtual_String_Vector;
    end record;
 
    overriding function Create
@@ -38,5 +41,8 @@ private
       Input : Input_Position;
       CIP   : Can_Interrupt_Paragraph;
       Ok    : in out Boolean);
+
+   Indent : VSS.Regular_Expressions.Regular_Expression;
+   --  Some spaces at the beginning of a string: "^ +"
 
 end Markdown.Implementation.Indented_Code_Blocks;

--- a/source/parser/implementation/markdown-parsers-gnatdoc_enable.adb
+++ b/source/parser/implementation/markdown-parsers-gnatdoc_enable.adb
@@ -1,0 +1,19 @@
+--
+--  Copyright (C) 2021-2022, AdaCore
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
+with Markdown.Implementation.Indented_Code_Blocks.GNATdoc;
+with Markdown.Implementation.List_Items;
+with Markdown.Implementation.Paragraphs;
+
+procedure Markdown.Parsers.GNATdoc_Enable
+  (Self : in out Markdown_Parser'Class) is
+begin
+   Self.Register_Block
+     (Markdown.Implementation.Indented_Code_Blocks.GNATdoc.Detector'Access);
+
+   Self.Register_Block (Markdown.Implementation.List_Items.Detector'Access);
+   Self.Register_Block (Markdown.Implementation.Paragraphs.Detector'Access);
+end Markdown.Parsers.GNATdoc_Enable;

--- a/source/parser/implementation/markdown-parsers-gnatdoc_enable.ads
+++ b/source/parser/implementation/markdown-parsers-gnatdoc_enable.ads
@@ -1,0 +1,10 @@
+--
+--  Copyright (C) 2021-2022, AdaCore
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
+procedure Markdown.Parsers.GNATdoc_Enable
+  (Self : in out Markdown_Parser'Class);
+--  Register gnatdoc specific block handlers
+pragma Preelaborate (Markdown.Parsers.GNATdoc_Enable);

--- a/source/parser/markdown-blocks-indented_code.ads
+++ b/source/parser/markdown-blocks-indented_code.ads
@@ -34,7 +34,7 @@ package Markdown.Blocks.Indented_Code is
 private
 
    type Indented_Code_Block_Access is access all
-     Markdown.Implementation.Indented_Code_Blocks.Indented_Code_Block;
+     Markdown.Implementation.Indented_Code_Blocks.Indented_Code_Block'Class;
 
    type Indented_Code_Block is new Ada.Finalization.Controlled with record
       Data : Indented_Code_Block_Access;

--- a/testsuite/commonmark/prints.adb
+++ b/testsuite/commonmark/prints.adb
@@ -1,0 +1,160 @@
+--
+--  Copyright (C) 2021-2022, AdaCore
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
+with VSS.Characters;
+with VSS.Strings;
+with VSS.Strings.Cursors.Markers;
+with VSS.Strings.Character_Iterators;
+
+with Markdown.Blocks.Indented_Code;
+with Markdown.Blocks.Paragraphs;
+
+package body Prints is
+   pragma Assertion_Policy (Check);
+
+   procedure Print_Annotated_Text
+     (Writer : in out HTML_Writers.Writer;
+      Text   : Markdown.Annotations.Annotated_Text)
+   is
+      use type VSS.Strings.Character_Count;
+
+      procedure Print
+        (From  : in out Positive;
+         Next  : in out VSS.Strings.Cursors.Markers.Character_Marker;
+         Limit : VSS.Strings.Character_Iterators.Character_Iterator);
+      --  From is an index in Text.Annotation to start from
+      --  Next is a not printed yet character in Text.Plain_Text
+      --  Dont go after Limit position in Text.Plain_Text
+
+      function "<="
+        (Segment  : VSS.Strings.Cursors.Markers.Segment_Marker;
+         Position : VSS.Strings.Character_Iterators.Character_Iterator)
+         return Boolean
+      is
+        (VSS.Strings.Cursors.Abstract_Cursor'Class (Segment).
+           Last_Character_Index <= Position.Character_Index);
+      --  Check if Segment ends before Position
+
+      -----------
+      -- Print --
+      -----------
+
+      procedure Print
+        (From  : in out Positive;
+         Next  : in out VSS.Strings.Cursors.Markers.Character_Marker;
+         Limit : VSS.Strings.Character_Iterators.Character_Iterator) is
+      begin
+         while From <= Text.Annotation.Last_Index and then
+           Text.Annotation (From).Segment <= Limit
+         loop
+            --  Print annotation here
+            null;
+            From := From + 1;
+         end loop;
+
+         if Next.Character_Index <= Limit.Character_Index then
+            Writer.Characters (Text.Plain_Text.Slice (Next, Limit));
+
+            declare
+               Iter : VSS.Strings.Character_Iterators.Character_Iterator :=
+                 Text.Plain_Text.At_Character (Limit);
+            begin
+               if Iter.Forward then
+                  Next := Iter.Marker;
+               end if;
+            end;
+         end if;
+      end Print;
+
+      From  : Positive := Text.Annotation.First_Index;
+      Next  : VSS.Strings.Cursors.Markers.Character_Marker :=
+        Text.Plain_Text.At_First_Character.Marker;
+   begin
+      Print
+        (From  => From,
+         Next  => Next,
+         Limit => Text.Plain_Text.At_Last_Character);
+   end Print_Annotated_Text;
+
+   -----------------
+   -- Print_Block --
+   -----------------
+
+   procedure Print_Block
+     (Writer : in out HTML_Writers.Writer;
+      Block  : Markdown.Blocks.Block)
+   is
+      New_Line : VSS.Strings.Virtual_String;
+   begin
+      New_Line.Append (VSS.Characters.Virtual_Character'Val (10));
+
+      if Block.Is_Paragraph then
+         Writer.Start_Element ("p");
+         Print_Annotated_Text (Writer, Block.To_Paragraph.Text);
+         Writer.End_Element ("p");
+
+      elsif Block.Is_Indented_Code_Block then
+         Writer.Start_Element ("pre");
+         Writer.Start_Element ("code");
+
+         for Line of Block.To_Indented_Code_Block.Text loop
+            Writer.Characters (Line);
+            Writer.Characters (New_Line);
+         end loop;
+
+         Writer.End_Element ("code");
+         Writer.End_Element ("pre");
+
+      elsif Block.Is_List then
+         Print_List (Writer, Block.To_List);
+      else
+         raise Program_Error;
+      end if;
+   end Print_Block;
+
+   procedure Print_Blocks
+     (Writer : in out HTML_Writers.Writer;
+      List   : Markdown.Block_Containers.Block_Container'Class) is
+   begin
+      for Block of List loop
+         Print_Block (Writer, Block);
+      end loop;
+   end Print_Blocks;
+
+   procedure Print_List
+     (Writer : in out HTML_Writers.Writer;
+      List   : Markdown.Blocks.Lists.List)
+   is
+      Tag : constant VSS.Strings.Virtual_String :=
+        VSS.Strings.To_Virtual_String
+          (if List.Is_Ordered then "ol" else "ul");
+
+      Attr : HTML_Writers.HTML_Attributes;
+   begin
+      if List.Is_Ordered then
+         declare
+            Image : constant Wide_Wide_String := List.Start'Wide_Wide_Image;
+         begin
+            if Image /= " 1" then
+               Attr.Append
+                 (("start",
+                   VSS.Strings.To_Virtual_String (Image (2 .. Image'Last))));
+            end if;
+         end;
+      end if;
+
+      Writer.Start_Element (Tag, Attr);
+
+      for Item of List loop
+         Writer.Start_Element ("li");
+         Print_Blocks (Writer, Item);
+         Writer.End_Element ("li");
+      end loop;
+
+      Writer.End_Element (Tag);
+   end Print_List;
+
+end Prints;

--- a/testsuite/commonmark/prints.ads
+++ b/testsuite/commonmark/prints.ads
@@ -1,0 +1,32 @@
+--
+--  Copyright (C) 2021-2022, AdaCore
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+
+with Markdown.Annotations;
+with Markdown.Block_Containers;
+with Markdown.Blocks;
+with Markdown.Blocks.Lists;
+
+with HTML_Writers;
+
+package Prints is
+
+   procedure Print_Block
+     (Writer : in out HTML_Writers.Writer;
+      Block  : Markdown.Blocks.Block);
+
+   procedure Print_List
+     (Writer : in out HTML_Writers.Writer;
+      List   : Markdown.Blocks.Lists.List);
+
+   procedure Print_Blocks
+     (Writer : in out HTML_Writers.Writer;
+      List   : Markdown.Block_Containers.Block_Container'Class);
+
+   procedure Print_Annotated_Text
+     (Writer : in out HTML_Writers.Writer;
+      Text   : Markdown.Annotations.Annotated_Text);
+
+end Prints;

--- a/testsuite/gnatdoc/gnatdoc_tests.adb
+++ b/testsuite/gnatdoc/gnatdoc_tests.adb
@@ -5,7 +5,7 @@
 --
 
 --  This program accepts Markdown on stdin and prints HTML on stdout.
---  See https://github.com/commonmark/commonmark-spec for more details.
+--  It uses gnatdoc specific blocks parsers.
 
 with Ada.Wide_Wide_Text_IO;
 
@@ -13,14 +13,17 @@ with VSS.Strings;
 
 with Markdown.Documents;
 with Markdown.Parsers;
+with Markdown.Parsers.GNATdoc_Enable;
 
 with HTML_Writers;
 with Prints;
 
-procedure Commonmark_Tests is
+procedure GNATdoc_Tests is
    Writer : HTML_Writers.Writer;
    Parser : Markdown.Parsers.Markdown_Parser;
 begin
+   Markdown.Parsers.GNATdoc_Enable (Parser);
+
    while not Ada.Wide_Wide_Text_IO.End_Of_File loop
       declare
          Line : constant Wide_Wide_String := Ada.Wide_Wide_Text_IO.Get_Line;
@@ -34,8 +37,6 @@ begin
    declare
       Document : constant Markdown.Documents.Document := Parser.Document;
    begin
-      --  Writer.Start_Element ("html");
       Prints.Print_Blocks (Writer, Document);
-      --  Writer.End_Element ("html");
    end;
-end Commonmark_Tests;
+end GNATdoc_Tests;


### PR DESCRIPTION
Add new testing executable. New procedure

    Markdown.Parsers.GNATdoc_Enable

configures the parser to accept GNATdoc code blocks.